### PR TITLE
Work movement support

### DIFF
--- a/src/atom.rs
+++ b/src/atom.rs
@@ -73,6 +73,13 @@ pub const PURCHASE_DATE: [u8; 4] = *b"purd";
 // ITunes 7.0
 pub const GAPLESS_PLAYBACK: [u8; 4] = *b"pgap";
 
+// Work, Movement
+pub const MOVEMENT_NAME: [u8; 4] = *b"\xa9mvn";
+pub const MOVEMENT_COUNT: [u8; 4] = *b"\xa9mvc";
+pub const MOVEMENT_INDEX: [u8; 4] = *b"\xa9mvi";
+pub const WORK: [u8; 4] = *b"\xa9wrk";
+pub const SHOW_MOVEMENT: [u8; 4] = *b"shwm";
+
 /// A structure that represents a MPEG-4 audio metadata atom.
 #[derive(Clone, PartialEq)]
 pub struct Atom {
@@ -464,10 +471,14 @@ pub fn metadata_atom() -> Atom {
                     .add_atom_with(KEYWORD, 0, Content::data_atom())
                     .add_atom_with(LYRICS, 0, Content::data_atom())
                     .add_atom_with(MEDIA_TYPE, 0, Content::data_atom())
+                    .add_atom_with(MOVEMENT_NAME, 0, Content::data_atom())
+                    .add_atom_with(MOVEMENT_COUNT, 0, Content::data_atom())
+                    .add_atom_with(MOVEMENT_INDEX, 0, Content::data_atom())
                     .add_atom_with(PODCAST, 0, Content::data_atom())
                     .add_atom_with(PODCAST_URL, 0, Content::data_atom())
                     .add_atom_with(PURCHASE_DATE, 0, Content::data_atom())
                     .add_atom_with(RATING, 0, Content::data_atom())
+                    .add_atom_with(SHOW_MOVEMENT, 0, Content::data_atom())
                     .add_atom_with(STANDARD_GENRE, 0, Content::data_atom())
                     .add_atom_with(TITLE, 0, Content::data_atom())
                     .add_atom_with(TRACK_NUMBER, 0, Content::data_atom())
@@ -476,6 +487,7 @@ pub fn metadata_atom() -> Atom {
                     .add_atom_with(TV_NETWORK_NAME, 0, Content::data_atom())
                     .add_atom_with(TV_SEASON, 0, Content::data_atom())
                     .add_atom_with(TV_SHOW_NAME, 0, Content::data_atom())
+                    .add_atom_with(WORK, 0, Content::data_atom())
                     .add_atom_with(YEAR, 0, Content::data_atom())
                     .add_atom_with(ARTWORK, 0, Content::data_atom(),
                     ),

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use byteorder::{BigEndian, WriteBytesExt};
 
-use crate::{atom, Atom, Content, Data};
+use crate::{atom, data::BE_SIGNED, Atom, Content, Data};
 
 /// A list of standard genres found in the `gnre` `Atom`.
 pub const GENRES: [(u16, &str); 80] = [
@@ -367,7 +367,7 @@ impl Tag {
     pub fn set_movement_count(&mut self, count: u16) {
         let mut vec: Vec<u8> = Vec::new();
         let _ = vec.write_u16::<BigEndian>(count).is_ok();
-        self.set_data(atom::MOVEMENT_COUNT, Data::Reserved(vec));
+        self.set_data(atom::MOVEMENT_COUNT, Data::Reserved(vec, Some(BE_SIGNED)));
     }
 
     /// Returns the movement index (©mvi).
@@ -390,7 +390,7 @@ impl Tag {
     pub fn set_movement_index(&mut self, index: u16) {
         let mut vec: Vec<u8> = Vec::new();
         let _ = vec.write_u16::<BigEndian>(index).is_ok();
-        self.set_data(atom::MOVEMENT_INDEX, Data::Reserved(vec));
+        self.set_data(atom::MOVEMENT_INDEX, Data::Reserved(vec, Some(BE_SIGNED)));
     }
 
     /// Returns the show movement flag (shwm).
@@ -413,7 +413,7 @@ impl Tag {
     /// Sets the show movement flag to true (shwm).
     pub fn set_show_movement(&mut self) {
         let vec = vec![1u8];
-        self.set_data(atom::SHOW_MOVEMENT, Data::Reserved(vec));
+        self.set_data(atom::SHOW_MOVEMENT, Data::Reserved(vec, Some(BE_SIGNED)));
     }
 
     /// Returns the title (©nam).
@@ -564,7 +564,7 @@ impl Tag {
         if genre_code > 0 && genre_code <= 80 {
             let mut vec: Vec<u8> = Vec::new();
             let _ = vec.write_u16::<BigEndian>(genre_code).is_ok();
-            self.set_data(atom::STANDARD_GENRE, Data::Reserved(vec));
+            self.set_data(atom::STANDARD_GENRE, Data::Reserved(vec, None));
         }
     }
 
@@ -617,7 +617,7 @@ impl Tag {
             let _ = vec.write_u16::<BigEndian>(i).is_ok();
         }
 
-        self.set_data(atom::TRACK_NUMBER, Data::Reserved(vec));
+        self.set_data(atom::TRACK_NUMBER, Data::Reserved(vec, None));
     }
 
     /// Removes the track number and the total number of tracks (trkn).
@@ -657,7 +657,7 @@ impl Tag {
             let _ = vec.write_u16::<BigEndian>(i).is_ok();
         }
 
-        self.set_data(atom::DISK_NUMBER, Data::Reserved(vec));
+        self.set_data(atom::DISK_NUMBER, Data::Reserved(vec, None));
     }
 
     /// Removes the disk number and the total number of disks (disk).
@@ -693,7 +693,7 @@ impl Tag {
 
         for a in &self.readonly_atoms {
             if a.ident == atom::MEDIA_HEADER {
-                if let Content::RawData(Data::Reserved(v)) = &a.content {
+                if let Content::RawData(Data::Reserved(v, _)) = &a.content {
                     vec = v;
                 }
             }
@@ -724,12 +724,12 @@ impl Tag {
     /// use mp4ameta::{Tag, Data};
     ///
     /// let mut tag = Tag::new();
-    /// tag.set_data(*b"test", Data::Reserved(vec![1,2,3,4,5,6]));
+    /// tag.set_data(*b"test", Data::Reserved(vec![1,2,3,4,5,6], None));
     /// assert_eq!(tag.reserved(*b"test").unwrap().to_vec(), vec![1,2,3,4,5,6]);
     /// ```
     pub fn reserved(&self, ident: [u8; 4]) -> Option<&Vec<u8>> {
         match self.data(ident) {
-            Some(Data::Reserved(v)) => Some(v),
+            Some(Data::Reserved(v, _)) => Some(v),
             _ => None,
         }
     }
@@ -925,5 +925,35 @@ mod tests {
         assert_eq!(tag.movement_index(), Some(index));
         assert_eq!(tag.show_movement(), Some(1));
         assert_eq!(tag.work(), Some(work));
+    }
+
+    #[test]
+    fn tags_with_type_identifier_implementation() {
+        let index = 1u16;
+        let count = 8u16;
+
+        let mut tag = Tag::new();
+
+        tag.set_movement_count(count);
+        tag.set_movement_index(index);
+        tag.set_show_movement();
+
+        if let Data::Reserved(_, ti) = tag.data(atom::MOVEMENT_COUNT).unwrap() {
+            assert_eq!(ti, &Some(BE_SIGNED));
+        } else {
+            assert!(false, "didn't find movement count reserved!")
+        }
+        if let Data::Reserved(_, ti) = tag.data(atom::MOVEMENT_INDEX).unwrap() {
+            assert_eq!(ti, &Some(BE_SIGNED));
+        } else {
+            assert!(false, "didn't find movement count reserved!")
+        }
+
+
+        if let Data::Reserved(_, ti) = tag.data(atom::SHOW_MOVEMENT).unwrap() {
+            assert_eq!(ti, &Some(BE_SIGNED));
+        } else {
+            assert!(false, "didn't find movement count reserved!")
+        }
     }
 }

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -332,6 +332,67 @@ impl Tag {
         self.remove_data(atom::LYRICS);
     }
 
+    /// Returns the movement (©mvn).
+    pub fn movement(&self) -> Option<&str> {
+        self.string(atom::MOVEMENT_NAME)
+    }
+
+    /// Removes the movement (©mvn).
+    pub fn remove_movement(&mut self) {
+        self.remove_data(atom::MOVEMENT_NAME)
+    }
+
+    /// Sets the movement (©mvn).
+    pub fn set_movement(&mut self, movement: impl Into<String>) {
+        self.set_data(atom::MOVEMENT_NAME, Data::Utf8(movement.into()));
+    }
+
+    /// Returns the movement count (©mvc).
+    pub fn movement_count(&self) -> Option<u16> {
+        todo!()
+    }
+
+    /// Removes the movement count (©mvc).
+    pub fn remove_movement_count(&mut self) {
+        self.remove_data(atom::MOVEMENT_COUNT)
+    }
+
+    /// Sets the movement count (©mvc).
+    pub fn set_movement_count(&mut self, _count: u16) {
+        todo!()
+    }
+
+    /// Returns the movement index (©mvi).
+    pub fn movement_index(&self) -> Option<u16> {
+        todo!()
+    }
+
+    /// Removes the movement index (©mvi).
+    pub fn remove_movement_index(&mut self) {
+        self.remove_data(atom::MOVEMENT_INDEX)
+    }
+
+    /// Sets the movement index (©mvi).
+    pub fn set_movement_index(&mut self, _index: u16) {
+        todo!()
+    }
+
+    /// Returns the show movement flag (shwm).
+    pub fn show_movement(&self) -> Option<u8> {
+        todo!()
+    }
+
+    /// Removes the show movement flag (shwm).
+    pub fn remove_show_movement(&mut self) {
+        self.remove_data(atom::MOVEMENT_INDEX)
+    }
+
+    // TODO: should we allow flag parameter? u8 or bool? assume true?
+    /// Sets the show movement flag to true (shwm).
+    pub fn set_show_movement(&mut self) {
+        todo!()
+    }
+
     /// Returns the title (©nam).
     pub fn title(&self) -> Option<&str> {
         self.string(atom::TITLE)
@@ -408,6 +469,21 @@ impl Tag {
     /// Removes the year (©day).
     pub fn remove_year(&mut self) {
         self.remove_data(atom::YEAR);
+    }
+
+    /// Returns the work (©wrk).
+    pub fn show_work(&self) -> Option<&str> {
+        self.string(atom::WORK)
+    }
+
+    /// Removes the work (©wrk).
+    pub fn remove_work(&mut self) {
+        self.remove_data(atom::WORK)
+    }
+
+    /// Sets the work (©wrk).
+    pub fn set_work(&mut self, work: impl Into<String>) {
+        self.set_data(atom::WORK, Data::Utf8(work.into()));
     }
 
     /// Returns the genre (gnre) or (©gen).

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -355,7 +355,7 @@ impl Tag {
             return None
         }
 
-        Some(u16::from_ne_bytes([vec[0], vec[1]]))
+        Some(u16::from_be_bytes([vec[0], vec[1]]))
     }
 
     /// Removes the movement count (©mvc).
@@ -378,7 +378,7 @@ impl Tag {
             return None
         }
 
-        Some(u16::from_ne_bytes([vec[0], vec[1]]))
+        Some(u16::from_be_bytes([vec[0], vec[1]]))
     }
 
     /// Removes the movement index (©mvi).

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -495,7 +495,7 @@ impl Tag {
     }
 
     /// Returns the work (©wrk).
-    pub fn show_work(&self) -> Option<&str> {
+    pub fn work(&self) -> Option<&str> {
         self.string(atom::WORK)
     }
 

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -349,7 +349,13 @@ impl Tag {
 
     /// Returns the movement count (©mvc).
     pub fn movement_count(&self) -> Option<u16> {
-        todo!()
+        let vec = self.reserved(atom::MOVEMENT_COUNT)?;
+
+        if vec.len() < 2 {
+            return None
+        }
+
+        Some(u16::from_ne_bytes([vec[0], vec[1]]))
     }
 
     /// Removes the movement count (©mvc).
@@ -358,13 +364,21 @@ impl Tag {
     }
 
     /// Sets the movement count (©mvc).
-    pub fn set_movement_count(&mut self, _count: u16) {
-        todo!()
+    pub fn set_movement_count(&mut self, count: u16) {
+        let mut vec: Vec<u8> = Vec::new();
+        let _ = vec.write_u16::<BigEndian>(count).is_ok();
+        self.set_data(atom::MOVEMENT_COUNT, Data::Reserved(vec));
     }
 
     /// Returns the movement index (©mvi).
     pub fn movement_index(&self) -> Option<u16> {
-        todo!()
+        let vec = self.reserved(atom::MOVEMENT_INDEX)?;
+
+        if vec.len() < 2 {
+            return None
+        }
+
+        Some(u16::from_ne_bytes([vec[0], vec[1]]))
     }
 
     /// Removes the movement index (©mvi).
@@ -373,13 +387,21 @@ impl Tag {
     }
 
     /// Sets the movement index (©mvi).
-    pub fn set_movement_index(&mut self, _index: u16) {
-        todo!()
+    pub fn set_movement_index(&mut self, index: u16) {
+        let mut vec: Vec<u8> = Vec::new();
+        let _ = vec.write_u16::<BigEndian>(index).is_ok();
+        self.set_data(atom::MOVEMENT_COUNT, Data::Reserved(vec));
     }
 
     /// Returns the show movement flag (shwm).
     pub fn show_movement(&self) -> Option<u8> {
-        todo!()
+        let vec = self.reserved(atom::SHOW_MOVEMENT)?;
+
+        if vec.len() < 1 {
+            return None
+        }
+
+        Some(vec[0])
     }
 
     /// Removes the show movement flag (shwm).
@@ -390,7 +412,8 @@ impl Tag {
     // TODO: should we allow flag parameter? u8 or bool? assume true?
     /// Sets the show movement flag to true (shwm).
     pub fn set_show_movement(&mut self) {
-        todo!()
+        let vec = vec![1u8];
+        self.set_data(atom::SHOW_MOVEMENT, Data::Reserved(vec));
     }
 
     /// Returns the title (©nam).

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -390,7 +390,7 @@ impl Tag {
     pub fn set_movement_index(&mut self, index: u16) {
         let mut vec: Vec<u8> = Vec::new();
         let _ = vec.write_u16::<BigEndian>(index).is_ok();
-        self.set_data(atom::MOVEMENT_COUNT, Data::Reserved(vec));
+        self.set_data(atom::MOVEMENT_INDEX, Data::Reserved(vec));
     }
 
     /// Returns the show movement flag (shwm).
@@ -406,7 +406,7 @@ impl Tag {
 
     /// Removes the show movement flag (shwm).
     pub fn remove_show_movement(&mut self) {
-        self.remove_data(atom::MOVEMENT_INDEX)
+        self.remove_data(atom::SHOW_MOVEMENT)
     }
 
     // TODO: should we allow flag parameter? u8 or bool? assume true?
@@ -893,5 +893,37 @@ impl Tag {
                 return;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn work_movement_handling() {
+        let movement = "my movement";
+        let index = 1u16;
+        let count = 8u16;
+        let work = "my work";
+
+        let mut tag = Tag::read_from_path("./tests/files/sample.m4a").unwrap();
+        assert_eq!(tag.movement(), None);
+        assert_eq!(tag.movement_count(), None);
+        assert_eq!(tag.movement_index(), None);
+        assert_eq!(tag.show_movement(), None);
+        assert_eq!(tag.work(), None);
+
+        tag.set_movement(movement);
+        tag.set_movement_count(count);
+        tag.set_movement_index(index);
+        tag.set_show_movement();
+        tag.set_work(work);
+
+        assert_eq!(tag.movement(), Some(movement));
+        assert_eq!(tag.movement_count(), Some(count));
+        assert_eq!(tag.movement_index(), Some(index));
+        assert_eq!(tag.show_movement(), Some(1));
+        assert_eq!(tag.work(), Some(work));
     }
 }


### PR DESCRIPTION
Fixes #3 

This PR hopefully implements correctly movement/work tags support. Note that I have no experience / knowledge about saving binary files and I it took a long time to figure out what to do. I didn't try heavy usage on this library, I just tried to set metadata and read it with external m4a tools (like [AtomicParsley](http://atomicparsley.sourceforge.net)). Please take extra care when reviewing my changes to make sure I didn't break anything...

A few thoughts about this PR:

* **Backwards compatibility**: I couldn't find a way to implement this without breaking backwards compatibility. My guidelines were to change as little as possible - I only changed the `Data::Reserved` type - which hopefully is not used much by external users of the library.
* API decisions: The *show movement* (`shwm`) flag is basically a boolean flag (although implemented as integer). I decided to make `set_show_movement` function without arguments which means you use `remove_show_movement` to disable. However If you prefer I can change it to accept a boolean or int as parameter.

Thank you very much for this crate. I was searching for a long time for a crate handle m4a 😄 .