### PR TITLE
bump mp4ameta_proc version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 byteorder = "1.3.4"
 lazy_static = "1.4.0"
-mp4ameta_proc = { path = "mp4ameta_proc", version = "0.1.0" }
+mp4ameta_proc = { path = "mp4ameta_proc", version = "0.1.1" }
 
 [dev-dependencies]
 walkdir = "2.3.1"


### PR DESCRIPTION
In the [lastest documentation](https://docs.rs/mp4ameta/0.6.0/mp4ameta/struct.Tag.html) some text meant to be wrapped within backticks is not properly wrapped. This is because you updated `mp4ameta_proc` 24 days ago but did not update its dependency in `mp4ameta`