### PR TITLE
Borrowed ident

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A library for reading and writing iTunes style MPEG-4 audio metadata.
 
-## Usage
+## Examples
 
 ### The easy way
 ```rust
@@ -22,8 +22,10 @@ tag.write_to_path("music.m4a").unwrap();
 
 ### The hard way
 ```rust
+use mp4ameta::{atom, Data, FourCC, Tag};
+
 let mut tag = Tag::read_from_path("music.m4a").unwrap();
-let artist_ident = Ident::bytes(*b"\xa9ART");
+let artist_ident = FourCC(*b"\xa9ART");
 
 let artist = tag.string(&artist_ident).next().unwrap();
 println!("{}", artist);
@@ -33,12 +35,12 @@ tag.set_data(artist_ident, Data::Utf8("artist".to_owned()));
 tag.write_to_path("music.m4a").unwrap();
 ```
 
-### Using freeform idents
+### Using freeform identifiers
 ```rust
-use mp4ameta::{Data, Ident, Tag};
+use mp4ameta::{Data, FreeformIdent, Tag};
 
 let mut tag = Tag::read_from_path("music.m4a").unwrap();
-let isrc_ident = Ident::freeform("com.apple.iTunes", "ISRC");
+let isrc_ident = FreeformIdent::new("com.apple.iTunes", "ISRC");
 
 let isrc = tag.string(&isrc_ident).next().unwrap();
 println!("{}", isrc);

--- a/mp4ameta_proc/src/lib.rs
+++ b/mp4ameta_proc/src/lib.rs
@@ -45,25 +45,25 @@ pub fn individual_string_value_accessor(input: TokenStream) -> TokenStream {
     format!(
         "
 /// ### {0}
-impl Tag<'_> {{
+impl Tag {{
     /// Returns the {1} (`{2}`).
     pub fn {3}(&self) -> Option<&str> {{
-        self.string(&Ident::Std({4})).next()
+        self.string(&{4}).next()
     }}
 
     /// Consumes and returns the {1} (`{2}`).
     pub fn take_{3}(&mut self) -> Option<String> {{
-        self.take_string(&Ident::Std({4})).next()
+        self.take_string(&{4}).next()
     }}
 
     /// Sets the {1} (`{2}`).
     pub fn set_{3}(&mut self, {3}: impl Into<String>) {{
-        self.set_data(Ident::Std({4}), Data::Utf8({3}.into()));
+        self.set_data({4}, Data::Utf8({3}.into()));
     }}
 
     /// Removes the {1} (`{2}`).
     pub fn remove_{3}(&mut self) {{
-        self.remove_data(&Ident::Std({4}));
+        self.remove_data(&{4});
     }}
 
     /// Returns the {1} formatted in an easily readable way.
@@ -98,40 +98,40 @@ pub fn multiple_string_values_accessor(input: TokenStream) -> TokenStream {
     format!(
         "
 /// ### {0}
-impl Tag<'_> {{
+impl Tag {{
     /// Returns all {2} (`{3}`).
     pub fn {5}(&self) -> impl Iterator<Item=&str> {{
-        self.string(&Ident::Std({6}))
+        self.string(&{6})
     }}
 
     /// Returns the first {1} (`{3}`).
     pub fn {4}(&self) -> Option<&str> {{
-        self.string(&Ident::Std({6})).next()
+        self.string(&{6}).next()
     }}
 
     /// Consumes and returns all {2} (`{3}`).
     pub fn take_{5}(&mut self) -> impl Iterator<Item=String> + '_ {{
-        self.take_string(&Ident::Std({6}))
+        self.take_string(&{6})
     }}
 
     /// Consumes all and returns the first {1} (`{3}`).
     pub fn take_{4}(&mut self) -> Option<String> {{
-        self.take_string(&Ident::Std({6})).next()
+        self.take_string(&{6}).next()
     }}
 
     /// Sets the {1} (`{3}`). This will remove all other {2}.
     pub fn set_{4}(&mut self, {4}: impl Into<String>) {{
-        self.set_data(Ident::Std({6}), Data::Utf8({4}.into()));
+        self.set_data({6}, Data::Utf8({4}.into()));
     }}
 
     /// Adds an {1} (`{3}`).
     pub fn add_{4}(&mut self, {4}: impl Into<String>) {{
-        self.add_data(Ident::Std({6}), Data::Utf8({4}.into()));
+        self.add_data({6}, Data::Utf8({4}.into()));
     }}
 
     /// Removes all {2} (`{3}`).
     pub fn remove_{5}(&mut self) {{
-        self.remove_data(&Ident::Std({6}));
+        self.remove_data(&{6});
     }}
 
     /// Returns all {2} formatted in an easily readable way.
@@ -166,10 +166,10 @@ pub fn flag_value_accessor(input: TokenStream) -> TokenStream {
     format!(
         "
 /// ### {0}
-impl Tag<'_> {{
+impl Tag {{
     /// Returns the {1} flag (`{2}`).
     pub fn {3}(&self) -> bool {{
-        let vec = match self.data(&Ident::Std({4})).next() {{
+        let vec = match self.data(&{4}).next() {{
             Some(Data::Reserved(v)) => v,
             Some(Data::BeSigned(v)) => v,
             _ => return false,
@@ -180,12 +180,12 @@ impl Tag<'_> {{
 
     /// Sets the {1} flag to true (`{2}`).
     pub fn set_{3}(&mut self) {{
-        self.set_data(Ident::Std({4}), Data::BeSigned(vec![1u8]));
+        self.set_data({4}, Data::BeSigned(vec![1u8]));
     }}
 
     /// Removes the {1} flag (`{2}`).
     pub fn remove_{3}(&mut self) {{
-        self.remove_data(&Ident::Std({4}))
+        self.remove_data(&{4})
     }}
 }}
     ",
@@ -202,10 +202,10 @@ pub fn integer_value_accessor(input: TokenStream) -> TokenStream {
     format!(
         "
 /// ### {0}
-impl Tag<'_> {{
+impl Tag {{
     /// Returns the {1} (`{2}`)
     pub fn {3}(&self) -> Option<u16> {{
-        let vec = match self.data(&Ident::Std({4})).next()? {{
+        let vec = match self.data(&{4}).next()? {{
             Data::Reserved(v) => v,
             Data::BeSigned(v) => v,
             _ => return None,
@@ -217,12 +217,12 @@ impl Tag<'_> {{
     /// Sets the {1} (`{2}`)
     pub fn set_{3}(&mut self, {3}: u16) {{
         let vec: Vec<u8> = {3}.to_be_bytes().to_vec();
-        self.set_data(Ident::Std({4}), Data::BeSigned(vec));
+        self.set_data({4}, Data::BeSigned(vec));
     }}
 
     /// Removes the {1} (`{2}`).
     pub fn remove_{3}(&mut self) {{
-        self.remove_data(&Ident::Std({4}));
+        self.remove_data(&{4});
     }}
 }}
     ",

--- a/mp4ameta_proc/src/lib.rs
+++ b/mp4ameta_proc/src/lib.rs
@@ -45,7 +45,7 @@ pub fn individual_string_value_accessor(input: TokenStream) -> TokenStream {
     format!(
         "
 /// ### {0}
-impl Tag {{
+impl Tag<'_> {{
     /// Returns the {1} (`{2}`).
     pub fn {3}(&self) -> Option<&str> {{
         self.string(&Ident::Std({4})).next()
@@ -98,7 +98,7 @@ pub fn multiple_string_values_accessor(input: TokenStream) -> TokenStream {
     format!(
         "
 /// ### {0}
-impl Tag {{
+impl Tag<'_> {{
     /// Returns all {2} (`{3}`).
     pub fn {5}(&self) -> impl Iterator<Item=&str> {{
         self.string(&Ident::Std({6}))
@@ -166,7 +166,7 @@ pub fn flag_value_accessor(input: TokenStream) -> TokenStream {
     format!(
         "
 /// ### {0}
-impl Tag {{
+impl Tag<'_> {{
     /// Returns the {1} flag (`{2}`).
     pub fn {3}(&self) -> bool {{
         let vec = match self.data(&Ident::Std({4})).next() {{
@@ -202,7 +202,7 @@ pub fn integer_value_accessor(input: TokenStream) -> TokenStream {
     format!(
         "
 /// ### {0}
-impl Tag {{
+impl Tag<'_> {{
     /// Returns the {1} (`{2}`)
     pub fn {3}(&self) -> Option<u16> {{
         let vec = match self.data(&Ident::Std({4})).next()? {{

--- a/src/core/atom/ident.rs
+++ b/src/core/atom/ident.rs
@@ -1,142 +1,161 @@
 use core::{fmt, ops::Deref};
 
 /// (`ftyp`) Identifier of an atom information about the filetype.
-pub const FILETYPE: AtomIdent = AtomIdent(*b"ftyp");
+pub const FILETYPE: FourCC = FourCC(*b"ftyp");
 /// (`mdat`)
-pub const MEDIA_DATA: AtomIdent = AtomIdent(*b"mdat");
+pub const MEDIA_DATA: FourCC = FourCC(*b"mdat");
 /// (`moov`) Identifier of an atom containing a structure of children storing metadata.
-pub const MOVIE: AtomIdent = AtomIdent(*b"moov");
+pub const MOVIE: FourCC = FourCC(*b"moov");
 /// (`mvhd`) Identifier of an atom containing information about the whole movie (or audio file).
-pub const MOVIE_HEADER: AtomIdent = AtomIdent(*b"mvhd");
+pub const MOVIE_HEADER: FourCC = FourCC(*b"mvhd");
 /// (`trak`) Identifier of an atom containing information about a single track.
-pub const TRACK: AtomIdent = AtomIdent(*b"trak");
+pub const TRACK: FourCC = FourCC(*b"trak");
 /// (`mdia`) Identifier of an atom containing information about a tracks media type and data.
-pub const MEDIA: AtomIdent = AtomIdent(*b"mdia");
+pub const MEDIA: FourCC = FourCC(*b"mdia");
 /// (`mdhd`) Identifier of an atom containing information about a track
-pub const MEDIA_HEADER: AtomIdent = AtomIdent(*b"mdhd");
+pub const MEDIA_HEADER: FourCC = FourCC(*b"mdhd");
 /// (`minf`)
-pub const METADATA_INFORMATION: AtomIdent = AtomIdent(*b"minf");
+pub const METADATA_INFORMATION: FourCC = FourCC(*b"minf");
 /// (`stbl`)
-pub const SAMPLE_TABLE: AtomIdent = AtomIdent(*b"stbl");
+pub const SAMPLE_TABLE: FourCC = FourCC(*b"stbl");
 /// (`stco`)
-pub const SAMPLE_TABLE_CHUNK_OFFSET: AtomIdent = AtomIdent(*b"stco");
+pub const SAMPLE_TABLE_CHUNK_OFFSET: FourCC = FourCC(*b"stco");
 /// (`udta`) Identifier of an atom containing user metadata.
-pub const USER_DATA: AtomIdent = AtomIdent(*b"udta");
+pub const USER_DATA: FourCC = FourCC(*b"udta");
 /// (`meta`) Identifier of an atom containing a metadata item list.
-pub const METADATA: AtomIdent = AtomIdent(*b"meta");
+pub const METADATA: FourCC = FourCC(*b"meta");
 /// (`ilst`) Identifier of an atom containing a list of metadata atoms.
-pub const ITEM_LIST: AtomIdent = AtomIdent(*b"ilst");
+pub const ITEM_LIST: FourCC = FourCC(*b"ilst");
 /// (`data`) Identifier of an atom containing typed data.
-pub const DATA: AtomIdent = AtomIdent(*b"data");
+pub const DATA: FourCC = FourCC(*b"data");
 /// (`mean`)
-pub const MEAN: AtomIdent = AtomIdent(*b"mean");
+pub const MEAN: FourCC = FourCC(*b"mean");
 /// (`name`)
-pub const NAME: AtomIdent = AtomIdent(*b"name");
+pub const NAME: FourCC = FourCC(*b"name");
 /// (`free`)
-pub const FREE: AtomIdent = AtomIdent(*b"free");
+pub const FREE: FourCC = FourCC(*b"free");
 
 /// (`----`)
-pub const FREEFORM: AtomIdent = AtomIdent(*b"----");
+pub const FREEFORM: FourCC = FourCC(*b"----");
 /// A identifier used internally as a wildcard.
-pub const WILDCARD: AtomIdent = AtomIdent([255, 255, 255, 255]);
+pub const WILDCARD: FourCC = FourCC([255, 255, 255, 255]);
 
 // iTunes 4.0 atoms
 /// (`rtng`)
-pub const ADVISORY_RATING: AtomIdent = AtomIdent(*b"rtng");
+pub const ADVISORY_RATING: FourCC = FourCC(*b"rtng");
 /// (`©alb`)
-pub const ALBUM: AtomIdent = AtomIdent(*b"\xa9alb");
+pub const ALBUM: FourCC = FourCC(*b"\xa9alb");
 /// (`aART`)
-pub const ALBUM_ARTIST: AtomIdent = AtomIdent(*b"aART");
+pub const ALBUM_ARTIST: FourCC = FourCC(*b"aART");
 /// (`©ART`)
-pub const ARTIST: AtomIdent = AtomIdent(*b"\xa9ART");
+pub const ARTIST: FourCC = FourCC(*b"\xa9ART");
 /// (`covr`)
-pub const ARTWORK: AtomIdent = AtomIdent(*b"covr");
+pub const ARTWORK: FourCC = FourCC(*b"covr");
 /// (`tmpo`)
-pub const BPM: AtomIdent = AtomIdent(*b"tmpo");
+pub const BPM: FourCC = FourCC(*b"tmpo");
 /// (`©cmt`)
-pub const COMMENT: AtomIdent = AtomIdent(*b"\xa9cmt");
+pub const COMMENT: FourCC = FourCC(*b"\xa9cmt");
 /// (`cpil`)
-pub const COMPILATION: AtomIdent = AtomIdent(*b"cpil");
+pub const COMPILATION: FourCC = FourCC(*b"cpil");
 /// (`©wrt`)
-pub const COMPOSER: AtomIdent = AtomIdent(*b"\xa9wrt");
+pub const COMPOSER: FourCC = FourCC(*b"\xa9wrt");
 /// (`cprt`)
-pub const COPYRIGHT: AtomIdent = AtomIdent(*b"cprt");
+pub const COPYRIGHT: FourCC = FourCC(*b"cprt");
 /// (`©gen`)
-pub const CUSTOM_GENRE: AtomIdent = AtomIdent(*b"\xa9gen");
+pub const CUSTOM_GENRE: FourCC = FourCC(*b"\xa9gen");
 /// (`disk`)
-pub const DISC_NUMBER: AtomIdent = AtomIdent(*b"disk");
+pub const DISC_NUMBER: FourCC = FourCC(*b"disk");
 /// (`©too`)
-pub const ENCODER: AtomIdent = AtomIdent(*b"\xa9too");
+pub const ENCODER: FourCC = FourCC(*b"\xa9too");
 /// (`gnre`)
-pub const STANDARD_GENRE: AtomIdent = AtomIdent(*b"gnre");
+pub const STANDARD_GENRE: FourCC = FourCC(*b"gnre");
 /// (`©nam`)
-pub const TITLE: AtomIdent = AtomIdent(*b"\xa9nam");
+pub const TITLE: FourCC = FourCC(*b"\xa9nam");
 /// (`trkn`)
-pub const TRACK_NUMBER: AtomIdent = AtomIdent(*b"trkn");
+pub const TRACK_NUMBER: FourCC = FourCC(*b"trkn");
 /// (`©day`)
-pub const YEAR: AtomIdent = AtomIdent(*b"\xa9day");
+pub const YEAR: FourCC = FourCC(*b"\xa9day");
 
 // iTunes 4.2 atoms
 /// (`©grp`)
-pub const GROUPING: AtomIdent = AtomIdent(*b"\xa9grp");
+pub const GROUPING: FourCC = FourCC(*b"\xa9grp");
 /// (`stik`)
-pub const MEDIA_TYPE: AtomIdent = AtomIdent(*b"stik");
+pub const MEDIA_TYPE: FourCC = FourCC(*b"stik");
 
 // iTunes 4.9 atoms
 /// (`catg`)
-pub const CATEGORY: AtomIdent = AtomIdent(*b"catg");
+pub const CATEGORY: FourCC = FourCC(*b"catg");
 /// (`keyw`)
-pub const KEYWORD: AtomIdent = AtomIdent(*b"keyw");
+pub const KEYWORD: FourCC = FourCC(*b"keyw");
 /// (`pcst`)
-pub const PODCAST: AtomIdent = AtomIdent(*b"pcst");
+pub const PODCAST: FourCC = FourCC(*b"pcst");
 /// (`egid`)
-pub const PODCAST_EPISODE_GLOBAL_UNIQUE_ID: AtomIdent = AtomIdent(*b"egid");
+pub const PODCAST_EPISODE_GLOBAL_UNIQUE_ID: FourCC = FourCC(*b"egid");
 /// (`purl`)
-pub const PODCAST_URL: AtomIdent = AtomIdent(*b"purl");
+pub const PODCAST_URL: FourCC = FourCC(*b"purl");
 
 // iTunes 5.0
 /// (`desc`)
-pub const DESCRIPTION: AtomIdent = AtomIdent(*b"desc");
+pub const DESCRIPTION: FourCC = FourCC(*b"desc");
 /// (`©lyr`)
-pub const LYRICS: AtomIdent = AtomIdent(*b"\xa9lyr");
+pub const LYRICS: FourCC = FourCC(*b"\xa9lyr");
 
 // iTunes 6.0
 /// (`tves`)
-pub const TV_EPISODE: AtomIdent = AtomIdent(*b"tves");
+pub const TV_EPISODE: FourCC = FourCC(*b"tves");
 /// (`tven`)
-pub const TV_EPISODE_NUMBER: AtomIdent = AtomIdent(*b"tven");
+pub const TV_EPISODE_NUMBER: FourCC = FourCC(*b"tven");
 /// (`tvnn`)
-pub const TV_NETWORK_NAME: AtomIdent = AtomIdent(*b"tvnn");
+pub const TV_NETWORK_NAME: FourCC = FourCC(*b"tvnn");
 /// (`tvsn`)
-pub const TV_SEASON: AtomIdent = AtomIdent(*b"tvsn");
+pub const TV_SEASON: FourCC = FourCC(*b"tvsn");
 /// (`tvsh`)
-pub const TV_SHOW_NAME: AtomIdent = AtomIdent(*b"tvsh");
+pub const TV_SHOW_NAME: FourCC = FourCC(*b"tvsh");
 
 // iTunes 6.0.2
 /// (`purd`)
-pub const PURCHASE_DATE: AtomIdent = AtomIdent(*b"purd");
+pub const PURCHASE_DATE: FourCC = FourCC(*b"purd");
 
 // iTunes 7.0
 /// (`pgap`)
-pub const GAPLESS_PLAYBACK: AtomIdent = AtomIdent(*b"pgap");
+pub const GAPLESS_PLAYBACK: FourCC = FourCC(*b"pgap");
 
 // Work, Movement
 /// (`©mvn`)
-pub const MOVEMENT: AtomIdent = AtomIdent(*b"\xa9mvn");
+pub const MOVEMENT: FourCC = FourCC(*b"\xa9mvn");
 /// (`©mvc`)
-pub const MOVEMENT_COUNT: AtomIdent = AtomIdent(*b"\xa9mvc");
+pub const MOVEMENT_COUNT: FourCC = FourCC(*b"\xa9mvc");
 /// (`©mvi`)
-pub const MOVEMENT_INDEX: AtomIdent = AtomIdent(*b"\xa9mvi");
+pub const MOVEMENT_INDEX: FourCC = FourCC(*b"\xa9mvi");
 /// (`©wrk`)
-pub const WORK: AtomIdent = AtomIdent(*b"\xa9wrk");
+pub const WORK: FourCC = FourCC(*b"\xa9wrk");
 /// (`shwm`)
-pub const SHOW_MOVEMENT: AtomIdent = AtomIdent(*b"shwm");
+pub const SHOW_MOVEMENT: FourCC = FourCC(*b"shwm");
 
-/// A 4 byte atom identifier.
+/// A trait providing information about an identifier.
+pub trait Ident {
+    /// Returns a 4 byte atom identifier.
+    fn fourcc(&self) -> Option<FourCC>;
+    /// Returns a freeform identifier.
+    fn freeform(&self) -> Option<FreeformIdent>;
+}
+
+/// Returns wheter the identifiers match.
+pub fn idents_match(a: &impl Ident, b: &impl Ident) -> bool {
+    a.fourcc() == b.fourcc() && a.freeform() == b.freeform()
+}
+
+/// A 4 byte atom identifier (four character code).
 #[derive(Clone, Copy, Default, Eq, PartialEq)]
-pub struct AtomIdent(pub [u8; 4]);
+pub struct FourCC(pub [u8; 4]);
 
-impl Deref for AtomIdent {
+impl PartialEq<dyn Ident> for FourCC {
+    fn eq(&self, other: &dyn Ident) -> bool {
+        other.fourcc().map_or(false, |f| *self == f)
+    }
+}
+
+impl Deref for FourCC {
     type Target = [u8; 4];
 
     fn deref(&self) -> &Self::Target {
@@ -144,93 +163,127 @@ impl Deref for AtomIdent {
     }
 }
 
-impl fmt::Debug for AtomIdent {
+impl Ident for FourCC {
+    fn fourcc(&self) -> Option<FourCC> {
+        Some(*self)
+    }
+
+    fn freeform(&self) -> Option<FreeformIdent> {
+        None
+    }
+}
+
+impl fmt::Debug for FourCC {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Ident({})", self.0.iter().map(|b| char::from(*b)).collect::<String>())
     }
 }
 
-impl fmt::Display for AtomIdent {
+impl fmt::Display for FourCC {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0.iter().map(|b| char::from(*b)).collect::<String>())
     }
 }
 
-/// A identifier for atoms
-#[derive(Clone, Debug, Eq)]
-pub enum Ident<'a> {
-    /// A standard identifier containing just an atom identifier.
-    Std(AtomIdent),
-    /// A identifier of a freeform (`----`) atom containing it's mean and name strings.
+/// An identifier of a freeform (`----`) atom containing borrowd mean and name strings.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FreeformIdent<'a> {
+    /// The mean string, typically in reverse domain notation.
+    mean: &'a str,
+    /// The name string used to identify the freeform atom.
+    name: &'a str,
+}
+
+impl Ident for FreeformIdent<'_> {
+    fn fourcc(&self) -> Option<FourCC> {
+        None
+    }
+
+    fn freeform(&self) -> Option<FreeformIdent> {
+        Some(self.clone())
+    }
+}
+
+impl fmt::Display for FreeformIdent<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "----:{}:{}", self.mean, self.name)
+    }
+}
+
+impl<'a> FreeformIdent<'a> {
+    /// Creates a new freeform ident containing the mean and name as borrowed strings.
+    pub fn new(mean: &'a str, name: &'a str) -> Self {
+        Self { mean, name }
+    }
+}
+
+/// An identifier for data.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataIdent {
+    /// A standard identifier containing a 4 byte atom identifier.
+    FourCC(FourCC),
+    /// An identifier of a freeform (`----`) atom containing owned mean and name strings.
     Freeform {
         /// The mean string, typically in reverse domain notation.
         mean: String,
-        /// The name string actually used to identify the freeform atom.
+        /// The name string used to identify the freeform atom.
         name: String,
     },
-    /// A identifier of a freeform (`----`) atom containing it's mean and name strings.
-    FreeformBorrowed {
-        /// The mean string, typically in reverse domain notation.
-        mean: &'a str,
-        /// The name string actually used to identify the freeform atom.
-        name: &'a str,
-    },
 }
 
-impl PartialEq for Ident<'_> {
-    fn eq(&self, other: &Self) -> bool {
-        if let (Self::Std(a), Self::Std(b)) = (self, other) {
-            return a == b;
-        }
-
-        let (ma, na) = match self {
-            Self::Freeform { mean, name } => (mean.as_str(), name.as_str()),
-            Self::FreeformBorrowed { mean, name } => (*mean, *name),
-            _ => return false,
-        };
-
-        let (mb, nb) = match other {
-            Self::Freeform { mean, name } => (mean.as_str(), name.as_str()),
-            Self::FreeformBorrowed { mean, name } => (*mean, *name),
-            _ => return false,
-        };
-
-        ma == mb && na == nb
-    }
-}
-
-impl fmt::Display for Ident<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Ident for DataIdent {
+    fn fourcc(&self) -> Option<FourCC> {
         match self {
-            Self::Std(ident) => write!(f, "{}", ident),
-            Self::Freeform { mean, name } => write!(f, "----:{}:{}", mean, name),
-            Self::FreeformBorrowed { mean, name } => write!(f, "----:{}:{}", mean, name),
+            Self::FourCC(i) => Some(*i),
+            Self::Freeform { .. } => None,
+        }
+    }
+
+    fn freeform(&self) -> Option<FreeformIdent> {
+        match self {
+            Self::FourCC(_) => None,
+            Self::Freeform { mean, name } => Some(FreeformIdent::new(mean.as_str(), name.as_str())),
         }
     }
 }
 
-impl From<&Self> for Ident<'_> {
-    fn from(value: &Self) -> Self {
-        value.clone()
+impl fmt::Display for DataIdent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::FourCC(ident) => write!(f, "{}", ident),
+            Self::Freeform { mean, name } => write!(f, "----:{}:{}", mean, name),
+        }
     }
 }
 
-impl Ident<'_> {
-    /// Creates a new identifier of type [`Ident::Freeform`](Self::Freeform) containing the owned
-    /// identifier, mean, and name.
-    pub fn freeform(mean: String, name: String) -> Self {
-        Self::Freeform { mean, name }
+impl From<FourCC> for DataIdent {
+    fn from(value: FourCC) -> Self {
+        Self::FourCC(value)
+    }
+}
+
+impl From<FreeformIdent<'_>> for DataIdent {
+    fn from(value: FreeformIdent) -> Self {
+        Self::freeform(value.mean, value.name)
+    }
+}
+
+impl From<&FreeformIdent<'_>> for DataIdent {
+    fn from(value: &FreeformIdent) -> Self {
+        Self::freeform(value.mean, value.name)
+    }
+}
+
+impl DataIdent {
+    /// Creates a new identifier of type [`DataIdent::Freeform`](Self::Freeform) containing the owned
+    /// mean, and name string.
+    pub fn freeform(mean: impl Into<String>, name: impl Into<String>) -> Self {
+        Self::Freeform { mean: mean.into(), name: name.into() }
     }
 
-    /// Creates a new identifier of type [`Ident::Freeform`](Self::Freeform) containing the owned
-    /// identifier, mean, and name.
-    pub fn freeform_static(mean: &'static str, name: &'static str) -> Self {
-        Self::FreeformBorrowed { mean, name }
-    }
-
-    /// Creates a new identifier of type [`Ident::Std`](Self::Std) containing an atom identifier
+    /// Creates a new identifier of type [`DataIdent::FourCC`](Self::FourCC) containing an atom identifier
     /// with the 4-byte identifier.
-    pub const fn bytes(bytes: [u8; 4]) -> Self {
-        Self::Std(AtomIdent(bytes))
+    pub const fn fourcc(bytes: [u8; 4]) -> Self {
+        Self::FourCC(FourCC(bytes))
     }
 }

--- a/src/core/content.rs
+++ b/src/core/content.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::io::{Read, Seek, SeekFrom, Write};
 
-use crate::{core::atom, data, Atom, AtomIdent, AtomT, Data, ErrorKind};
+use crate::{core::atom, data, Atom, AtomT, Data, ErrorKind, FourCC};
 
 /// An enum representing the different types of content an atom might have.
 #[derive(Clone, Eq, PartialEq)]
@@ -102,7 +102,7 @@ impl Content {
     }
 
     /// Returns a reference to the first children atom matching the `identifier`, if present.
-    pub fn child(&self, ident: AtomIdent) -> Option<&Atom> {
+    pub fn child(&self, ident: FourCC) -> Option<&Atom> {
         self.iter().find(|a| a.ident == ident)
     }
 
@@ -115,7 +115,7 @@ impl Content {
     }
 
     /// Returns a mutable reference to the first children atom matching the `identfier`, if present.
-    pub fn child_mut(&mut self, ident: AtomIdent) -> Option<&mut Atom> {
+    pub fn child_mut(&mut self, ident: FourCC) -> Option<&mut Atom> {
         self.iter_mut().find(|a| a.ident == ident)
     }
 
@@ -128,7 +128,7 @@ impl Content {
     }
 
     /// Consumes self and returns the first children atom matching the `identfier`, if present.
-    pub fn take_child(self, ident: AtomIdent) -> Option<Atom> {
+    pub fn take_child(self, ident: FourCC) -> Option<Atom> {
         self.into_iter().find(|a| a.ident == ident)
     }
 
@@ -266,7 +266,7 @@ impl ContentT {
     }
 
     /// Returns a reference to the first children atom matching the `identifier`, if present.
-    pub fn child(&self, ident: AtomIdent) -> Option<&AtomT> {
+    pub fn child(&self, ident: FourCC) -> Option<&AtomT> {
         self.iter().find(|a| a.ident == ident)
     }
 
@@ -279,7 +279,7 @@ impl ContentT {
     }
 
     /// Returns a mutable reference to the first children atom matching the `identfier`, if present.
-    pub fn child_mut(&mut self, ident: AtomIdent) -> Option<&mut AtomT> {
+    pub fn child_mut(&mut self, ident: FourCC) -> Option<&mut AtomT> {
         self.iter_mut().find(|a| a.ident == ident)
     }
 
@@ -292,7 +292,7 @@ impl ContentT {
     }
 
     /// Consumes self and returns the first children atom matching the `identfier`, if present.
-    pub fn take_child(self, ident: AtomIdent) -> Option<AtomT> {
+    pub fn take_child(self, ident: FourCC) -> Option<AtomT> {
         self.into_iter().find(|a| a.ident == ident)
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use std::{error, fmt, io, string};
 
-use crate::AtomIdent;
+use crate::FourCC;
 
 /// Type alias for the result of tag operations.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -9,7 +9,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug)]
 pub enum ErrorKind {
     /// An error kind indicating that an atom could not be found. Contains the atom's identifier.
-    AtomNotFound(AtomIdent),
+    AtomNotFound(FourCC),
     /// An error kind indicating that an IO error has occurred. Contains the original `io::Error`.
     Io(io::Error),
     /// An error kind indicating that the filetype read from the ftyp atom was invalid. Contains

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //! use mp4ameta::{Data, Ident, Tag};
 //!
 //! let mut tag = Tag::read_from_path("music.m4a").unwrap();
-//! let isrc_ident = Ident::freeform("com.apple.iTunes", "ISRC");
+//! let isrc_ident = Ident::freeform_static("com.apple.iTunes", "ISRC");
 //!
 //! let isrc = tag.string(&isrc_ident).next().unwrap();
 //! println!("{}", isrc);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! A library for reading and writing iTunes style MPEG-4 audio metadata.
 //!
-//! # Example
+//! # Examples
 //!
 //! ## The easy way
 //! ```no_run
@@ -15,10 +15,10 @@
 //!
 //! ## The hard way
 //! ```no_run
-//! use mp4ameta::{atom, Data, Ident, Tag};
+//! use mp4ameta::{atom, Data, FourCC, Tag};
 //!
 //! let mut tag = Tag::read_from_path("music.m4a").unwrap();
-//! let artist_ident = Ident::bytes(*b"\xa9ART");
+//! let artist_ident = FourCC(*b"\xa9ART");
 //!
 //! let artist = tag.string(&artist_ident).next().unwrap();
 //! println!("{}", artist);
@@ -28,12 +28,12 @@
 //! tag.write_to_path("music.m4a").unwrap();
 //! ```
 //!
-//! ## Using freeform idents
+//! ## Using freeform identifiers
 //! ```no_run
-//! use mp4ameta::{Data, Ident, Tag};
+//! use mp4ameta::{Data, FreeformIdent, Tag};
 //!
 //! let mut tag = Tag::read_from_path("music.m4a").unwrap();
-//! let isrc_ident = Ident::freeform_static("com.apple.iTunes", "ISRC");
+//! let isrc_ident = FreeformIdent::new("com.apple.iTunes", "ISRC");
 //!
 //! let isrc = tag.string(&isrc_ident).next().unwrap();
 //! println!("{}", isrc);
@@ -47,7 +47,7 @@
 #[macro_use]
 extern crate lazy_static;
 
-pub use crate::core::atom::{self, Atom, AtomData, AtomIdent, AtomT, Ident};
+pub use crate::core::atom::{self, Atom, AtomData, AtomT, DataIdent, FourCC, FreeformIdent, Ident};
 pub use crate::core::content::{Content, ContentT};
 pub use crate::core::data::{self, Data};
 pub use crate::core::types::{self, AdvisoryRating, MediaType};

--- a/src/tag/genre.rs
+++ b/src/tag/genre.rs
@@ -1,7 +1,4 @@
-use crate::{
-    atom::{self, Ident},
-    Data, Tag,
-};
+use crate::{atom, Data, Tag};
 
 /// A list of standard genre codes and values found in the `gnre` atom. This list is equal to the
 /// ID3v1 genre list but all codes are incremented by 1.
@@ -89,10 +86,10 @@ pub const STANDARD_GENRES: [(u16, &str); 80] = [
 ];
 
 /// ### Standard genre
-impl<'a> Tag<'a> {
+impl Tag {
     /// Returns all standard genres (`gnre`).
-    pub fn standard_genres<'b>(&'b self) -> impl Iterator<Item = u16> + 'b {
-        self.bytes(&Ident::Std(atom::STANDARD_GENRE)).filter_map(|v| {
+    pub fn standard_genres(&self) -> impl Iterator<Item = u16> + '_ {
+        self.bytes(&atom::STANDARD_GENRE).filter_map(|v| {
             if v.len() < 2 {
                 None
             } else {
@@ -110,7 +107,7 @@ impl<'a> Tag<'a> {
     pub fn set_standard_genre(&mut self, genre_code: u16) {
         if genre_code > 0 && genre_code <= 80 {
             let vec: Vec<u8> = genre_code.to_be_bytes().to_vec();
-            self.set_data(Ident::Std(atom::STANDARD_GENRE), Data::Reserved(vec));
+            self.set_data(atom::STANDARD_GENRE, Data::Reserved(vec));
         }
     }
 
@@ -118,13 +115,13 @@ impl<'a> Tag<'a> {
     pub fn add_standard_genre(&mut self, genre_code: u16) {
         if genre_code > 0 && genre_code <= 80 {
             let vec: Vec<u8> = genre_code.to_be_bytes().to_vec();
-            self.add_data(Ident::Std(atom::STANDARD_GENRE), Data::Reserved(vec))
+            self.add_data(atom::STANDARD_GENRE, Data::Reserved(vec))
         }
     }
 
     /// Removes all standard genres (`gnre`).
     pub fn remove_standard_genres(&mut self) {
-        self.remove_data(&Ident::Std(atom::STANDARD_GENRE));
+        self.remove_data(&atom::STANDARD_GENRE);
     }
 }
 
@@ -132,7 +129,7 @@ impl<'a> Tag<'a> {
 ///
 /// These are convenience functions that combine the values from the standard genre (`gnre`) and
 /// custom genre (`©gen`).
-impl Tag<'_> {
+impl Tag {
     /// Returns all genres (`gnre` or `©gen`).
     pub fn genres(&self) -> impl Iterator<Item = &str> {
         self.standard_genres()

--- a/src/tag/genre.rs
+++ b/src/tag/genre.rs
@@ -89,9 +89,9 @@ pub const STANDARD_GENRES: [(u16, &str); 80] = [
 ];
 
 /// ### Standard genre
-impl Tag {
+impl<'a> Tag<'a> {
     /// Returns all standard genres (`gnre`).
-    pub fn standard_genres(&self) -> impl Iterator<Item = u16> + '_ {
+    pub fn standard_genres<'b>(&'b self) -> impl Iterator<Item = u16> + 'b {
         self.bytes(&Ident::Std(atom::STANDARD_GENRE)).filter_map(|v| {
             if v.len() < 2 {
                 None
@@ -132,7 +132,7 @@ impl Tag {
 ///
 /// These are convenience functions that combine the values from the standard genre (`gnre`) and
 /// custom genre (`©gen`).
-impl Tag {
+impl Tag<'_> {
     /// Returns all genres (`gnre` or `©gen`).
     pub fn genres(&self) -> impl Iterator<Item = &str> {
         self.standard_genres()

--- a/src/tag/tuple.rs
+++ b/src/tag/tuple.rs
@@ -1,16 +1,13 @@
-use crate::{
-    atom::{self, Ident},
-    Data, Tag,
-};
+use crate::{atom, Data, Tag};
 
 /// ### Track
 ///
 /// The track number and total number of tracks are stored in a tuple. If only one is present the
 /// other is represented as 0 and will be treated as if nonexistent.
-impl<'a> Tag<'a> {
+impl Tag {
     /// Returns the track number and the total number of tracks (`trkn`).
     pub fn track(&self) -> (Option<u16>, Option<u16>) {
-        let vec = match self.bytes(&Ident::Std(atom::TRACK_NUMBER)).next() {
+        let vec = match self.bytes(&atom::TRACK_NUMBER).next() {
             Some(v) => v,
             None => return (None, None),
         };
@@ -23,43 +20,41 @@ impl<'a> Tag<'a> {
 
     /// Returns the track number (`trkn`).
     pub fn track_number(&self) -> Option<u16> {
-        let vec = self.bytes(&Ident::Std(atom::TRACK_NUMBER)).next()?;
+        let vec = self.bytes(&atom::TRACK_NUMBER).next()?;
 
         number(vec)
     }
 
     /// Returns the total number of tracks (`trkn`).
     pub fn total_tracks(&self) -> Option<u16> {
-        let vec = self.bytes(&Ident::Std(atom::TRACK_NUMBER)).next()?;
+        let vec = self.bytes(&atom::TRACK_NUMBER).next()?;
 
         total(vec)
     }
 
-    fn set_new_track(&'a mut self, track_number: u16, total_tracks: u16) {
+    fn set_new_track(&mut self, track_number: u16, total_tracks: u16) {
         let vec = vec![0u16, track_number, total_tracks, 0u16]
             .into_iter()
             .flat_map(|u| u.to_be_bytes().to_vec())
             .collect();
 
-        self.set_data(Ident::Std(atom::TRACK_NUMBER), Data::Reserved(vec));
+        self.set_data(atom::TRACK_NUMBER, Data::Reserved(vec));
     }
 
     /// Sets the track number and the total number of tracks (`trkn`).
-    pub fn set_track(&'a mut self, track_number: u16, total_tracks: u16) {
-        let vec = self.bytes_mut(&Ident::Std(atom::TRACK_NUMBER)).next();
-        if let Some(v) = vec {
+    pub fn set_track(&mut self, track_number: u16, total_tracks: u16) {
+        if let Some(v) = self.bytes_mut(&atom::TRACK_NUMBER).next() {
             set_total(v, total_tracks);
             set_number(v, track_number);
             return;
-        } else {
-            drop(vec);
-            self.set_new_track(track_number, total_tracks);
         }
+
+        self.set_new_track(track_number, total_tracks);
     }
 
     /// Sets the track number (`trkn`).
-    pub fn set_track_number(&'a mut self, track_number: u16) {
-        if let Some(v) = self.bytes_mut(&Ident::Std(atom::TRACK_NUMBER)).next() {
+    pub fn set_track_number(&mut self, track_number: u16) {
+        if let Some(v) = self.bytes_mut(&atom::TRACK_NUMBER).next() {
             set_number(v, track_number);
             return;
         }
@@ -68,8 +63,8 @@ impl<'a> Tag<'a> {
     }
 
     /// Sets the total number of tracks (`trkn`).
-    pub fn set_total_tracks(&'a mut self, total_tracks: u16) {
-        if let Some(v) = self.bytes_mut(&Ident::Std(atom::TRACK_NUMBER)).next() {
+    pub fn set_total_tracks(&mut self, total_tracks: u16) {
+        if let Some(v) = self.bytes_mut(&atom::TRACK_NUMBER).next() {
             set_total(v, total_tracks);
             return;
         }
@@ -79,12 +74,12 @@ impl<'a> Tag<'a> {
 
     /// Removes the track number and the total number of tracks (`trkn`).
     pub fn remove_track(&mut self) {
-        self.remove_data(&Ident::Std(atom::TRACK_NUMBER));
+        self.remove_data(&atom::TRACK_NUMBER);
     }
 
     /// Removes the track number, preserving the total number of tracks if present (`trkn`).
-    pub fn remove_track_number(&'a mut self) {
-        if let Some(v) = self.bytes_mut(&Ident::Std(atom::TRACK_NUMBER)).next() {
+    pub fn remove_track_number(&mut self) {
+        if let Some(v) = self.bytes_mut(&atom::TRACK_NUMBER).next() {
             if v.len() >= 6 && !(v[4] == 0 && v[5] == 0) {
                 v[2] = 0;
                 v[3] = 0;
@@ -95,8 +90,8 @@ impl<'a> Tag<'a> {
     }
 
     /// Removes the total number of tracks, preserving the track number if present (`trkn`).
-    pub fn remove_total_tracks(&'a mut self) {
-        if let Some(v) = self.bytes_mut(&Ident::Std(atom::TRACK_NUMBER)).next() {
+    pub fn remove_total_tracks(&mut self) {
+        if let Some(v) = self.bytes_mut(&atom::TRACK_NUMBER).next() {
             if v.len() >= 4 && !(v[2] == 0 && v[3] == 0) {
                 v[4] = 0;
                 v[5] = 0;
@@ -121,10 +116,10 @@ impl<'a> Tag<'a> {
 ///
 /// The disc number and total number of discs are stored in a tuple. If only one is present the
 /// other is represented as 0 and will be treated as if nonexistent.
-impl<'a> Tag<'a> {
+impl Tag {
     /// Returns the disc number and total number of discs (`disk`).
     pub fn disc(&self) -> (Option<u16>, Option<u16>) {
-        let vec = match self.bytes(&Ident::Std(atom::DISC_NUMBER)).next() {
+        let vec = match self.bytes(&atom::DISC_NUMBER).next() {
             Some(v) => v,
             None => return (None, None),
         };
@@ -137,14 +132,14 @@ impl<'a> Tag<'a> {
 
     /// Returns the disc number (`disk`).
     pub fn disc_number(&self) -> Option<u16> {
-        let vec = self.bytes(&Ident::Std(atom::DISC_NUMBER)).next()?;
+        let vec = self.bytes(&atom::DISC_NUMBER).next()?;
 
         number(vec)
     }
 
     /// Returns the total number of discs (`disk`).
     pub fn total_discs(&self) -> Option<u16> {
-        let vec = self.bytes(&Ident::Std(atom::DISC_NUMBER)).next()?;
+        let vec = self.bytes(&atom::DISC_NUMBER).next()?;
 
         total(vec)
     }
@@ -155,12 +150,12 @@ impl<'a> Tag<'a> {
             .flat_map(|u| u.to_be_bytes().to_vec())
             .collect();
 
-        self.set_data(Ident::Std(atom::DISC_NUMBER), Data::Reserved(vec));
+        self.set_data(atom::DISC_NUMBER, Data::Reserved(vec));
     }
 
     /// Sets the disc number and the total number of discs (`disk`).
-    pub fn set_disc(&'a mut self, disc_number: u16, total_discs: u16) {
-        if let Some(v) = self.bytes_mut(&Ident::Std(atom::DISC_NUMBER)).next() {
+    pub fn set_disc(&mut self, disc_number: u16, total_discs: u16) {
+        if let Some(v) = self.bytes_mut(&atom::DISC_NUMBER).next() {
             set_total(v, total_discs);
             set_number(v, disc_number);
             return;
@@ -170,8 +165,8 @@ impl<'a> Tag<'a> {
     }
 
     /// Sets the disc number (`disk`).
-    pub fn set_disc_number(&'a mut self, disc_number: u16) {
-        if let Some(v) = self.bytes_mut(&Ident::Std(atom::DISC_NUMBER)).next() {
+    pub fn set_disc_number(&mut self, disc_number: u16) {
+        if let Some(v) = self.bytes_mut(&atom::DISC_NUMBER).next() {
             set_number(v, disc_number);
             return;
         }
@@ -180,8 +175,8 @@ impl<'a> Tag<'a> {
     }
 
     /// Sets the total number of discs (`disk`).
-    pub fn set_total_discs(&'a mut self, total_discs: u16) {
-        if let Some(v) = self.bytes_mut(&Ident::Std(atom::DISC_NUMBER)).next() {
+    pub fn set_total_discs(&mut self, total_discs: u16) {
+        if let Some(v) = self.bytes_mut(&atom::DISC_NUMBER).next() {
             set_total(v, total_discs);
             return;
         }
@@ -191,12 +186,12 @@ impl<'a> Tag<'a> {
 
     /// Removes the disc number and the total number of discs (`disk`).
     pub fn remove_disc(&mut self) {
-        self.remove_data(&Ident::Std(atom::DISC_NUMBER));
+        self.remove_data(&atom::DISC_NUMBER);
     }
 
     /// Removes the disc number, preserving the total number of discs if present (`disk`).
-    pub fn remove_disc_number(&'a mut self) {
-        if let Some(v) = self.bytes_mut(&Ident::Std(atom::DISC_NUMBER)).next() {
+    pub fn remove_disc_number(&mut self) {
+        if let Some(v) = self.bytes_mut(&atom::DISC_NUMBER).next() {
             if v.len() >= 6 && !(v[4] == 0 && v[5] == 0) {
                 v[2] = 0;
                 v[3] = 0;
@@ -207,8 +202,8 @@ impl<'a> Tag<'a> {
     }
 
     /// Removes the total number of discs, preserving the disc number if present (`disk`).
-    pub fn remove_total_discs(&'a mut self) {
-        if let Some(v) = self.bytes_mut(&Ident::Std(atom::DISC_NUMBER)).next() {
+    pub fn remove_total_discs(&mut self) {
+        if let Some(v) = self.bytes_mut(&atom::DISC_NUMBER).next() {
             if v.len() >= 4 && !(v[2] == 0 && v[3] == 0) {
                 v[4] = 0;
                 v[5] = 0;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -79,7 +79,10 @@ fn verify_sample_data() {
     assert_eq!(tag.artwork(), Some(&Data::Png(fs::read("files/artwork.png").unwrap())));
     assert_eq!(tag.duration().ok(), Some(0.486));
     assert_eq!(tag.filetype(), Some("M4A \u{0}\u{0}\u{2}\u{0}isomiso2"));
-    assert_eq!(tag.string(&Ident::freeform("com.apple.iTunes", "ISRC")).next(), Some("TEST ISRC"));
+    assert_eq!(
+        tag.string(&Ident::freeform_static("com.apple.iTunes", "ISRC")).next(),
+        Some("TEST ISRC")
+    );
 }
 
 #[test]
@@ -108,7 +111,7 @@ fn write() {
     tag.set_track(3, 7);
     tag.set_year("1998");
     tag.set_artwork(Data::Jpeg(b"NEW ARTWORK".to_vec()));
-    tag.set_data(Ident::freeform("com.apple.iTunes", "ISRC"), Data::Utf8("NEW ISRC".into()));
+    tag.set_data(Ident::freeform_static("com.apple.iTunes", "ISRC"), Data::Utf8("NEW ISRC".into()));
 
     println!("copying files/sample.m4a to target/write.m4a...");
     std::fs::copy("files/sample.m4a", "target/write.m4a").unwrap();
@@ -147,7 +150,10 @@ fn write() {
     assert_eq!(tag.artwork(), Some(&Data::Jpeg(b"NEW ARTWORK".to_vec())));
     assert_eq!(tag.duration().ok(), Some(0.486));
     assert_eq!(tag.filetype(), Some("M4A \u{0}\u{0}\u{2}\u{0}isomiso2"));
-    assert_eq!(tag.string(&Ident::freeform("com.apple.iTunes", "ISRC")).next(), Some("NEW ISRC"));
+    assert_eq!(
+        tag.string(&Ident::freeform_static("com.apple.iTunes", "ISRC")).next(),
+        Some("NEW ISRC")
+    );
 
     println!("deleting target/write.m4a...");
     std::fs::remove_file("target/write.m4a").unwrap();
@@ -275,7 +281,7 @@ fn dump() {
     tag.set_track(7, 13);
     tag.set_year("2013");
     tag.set_artwork(Data::Png(b"TEST ARTWORK".to_vec()));
-    tag.set_data(Ident::freeform("com.apple.iTunes", "ISRC"), Data::Utf8("NEW ISRC".into()));
+    tag.set_data(Ident::freeform_static("com.apple.iTunes", "ISRC"), Data::Utf8("NEW ISRC".into()));
 
     println!("dumping...");
     tag.dump_to_path("target/dump.m4a").unwrap();
@@ -309,7 +315,10 @@ fn dump() {
     assert_eq!(tag.total_tracks(), Some(13));
     assert_eq!(tag.year(), Some("2013"));
     assert_eq!(tag.artwork(), Some(&Data::Png(b"TEST ARTWORK".to_vec())));
-    assert_eq!(tag.string(&Ident::freeform("com.apple.iTunes", "ISRC")).next(), Some("NEW ISRC"));
+    assert_eq!(
+        tag.string(&Ident::freeform_static("com.apple.iTunes", "ISRC")).next(),
+        Some("NEW ISRC")
+    );
 
     println!("deleting target/dump.m4a...");
     std::fs::remove_file("target/dump.m4a").unwrap();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,6 @@
-use mp4ameta::{AdvisoryRating, Data, Ident, MediaType, Tag, STANDARD_GENRES};
+use mp4ameta::{
+    atom::FreeformIdent, AdvisoryRating, Data, DataIdent, MediaType, Tag, STANDARD_GENRES,
+};
 use std::fs;
 use walkdir::WalkDir;
 
@@ -80,7 +82,7 @@ fn verify_sample_data() {
     assert_eq!(tag.duration().ok(), Some(0.486));
     assert_eq!(tag.filetype(), Some("M4A \u{0}\u{0}\u{2}\u{0}isomiso2"));
     assert_eq!(
-        tag.string(&Ident::freeform_static("com.apple.iTunes", "ISRC")).next(),
+        tag.string(&FreeformIdent::new("com.apple.iTunes", "ISRC")).next(),
         Some("TEST ISRC")
     );
 }
@@ -111,7 +113,7 @@ fn write() {
     tag.set_track(3, 7);
     tag.set_year("1998");
     tag.set_artwork(Data::Jpeg(b"NEW ARTWORK".to_vec()));
-    tag.set_data(Ident::freeform_static("com.apple.iTunes", "ISRC"), Data::Utf8("NEW ISRC".into()));
+    tag.set_data(DataIdent::freeform("com.apple.iTunes", "ISRC"), Data::Utf8("NEW ISRC".into()));
 
     println!("copying files/sample.m4a to target/write.m4a...");
     std::fs::copy("files/sample.m4a", "target/write.m4a").unwrap();
@@ -151,7 +153,7 @@ fn write() {
     assert_eq!(tag.duration().ok(), Some(0.486));
     assert_eq!(tag.filetype(), Some("M4A \u{0}\u{0}\u{2}\u{0}isomiso2"));
     assert_eq!(
-        tag.string(&Ident::freeform_static("com.apple.iTunes", "ISRC")).next(),
+        tag.string(&FreeformIdent::new("com.apple.iTunes", "ISRC")).next(),
         Some("NEW ISRC")
     );
 
@@ -281,7 +283,7 @@ fn dump() {
     tag.set_track(7, 13);
     tag.set_year("2013");
     tag.set_artwork(Data::Png(b"TEST ARTWORK".to_vec()));
-    tag.set_data(Ident::freeform_static("com.apple.iTunes", "ISRC"), Data::Utf8("NEW ISRC".into()));
+    tag.set_data(DataIdent::freeform("com.apple.iTunes", "ISRC"), Data::Utf8("NEW ISRC".into()));
 
     println!("dumping...");
     tag.dump_to_path("target/dump.m4a").unwrap();
@@ -316,7 +318,7 @@ fn dump() {
     assert_eq!(tag.year(), Some("2013"));
     assert_eq!(tag.artwork(), Some(&Data::Png(b"TEST ARTWORK".to_vec())));
     assert_eq!(
-        tag.string(&Ident::freeform_static("com.apple.iTunes", "ISRC")).next(),
+        tag.string(&FreeformIdent::new("com.apple.iTunes", "ISRC")).next(),
         Some("NEW ISRC")
     );
 


### PR DESCRIPTION
Enables the use of borrowed strings inside a freeform identifier to reduce unnecessary string allocations. (#12)